### PR TITLE
Add missing python-dotenv dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1992,6 +1992,21 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "python-dotenv"
+version = "1.0.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 description = "YAML parser and emitter for Python"
@@ -2314,4 +2329,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.13"
-content-hash = "030c2ac38bcedec185a3d4e2e982c2d3660f3f5db5b0bc34ed611be0961b4fd3"
+content-hash = "3696abfb377882c2e8001236d9742be26f195f664fd30bff0465108e5be0e92b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ boto3 = "^1.34.0"
 jinja2 = "^3.1.2"
 networkx = "^3.1"
 matplotlib = "^3.7.0"
+python-dotenv = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0.0"


### PR DESCRIPTION
## Summary
- Add python-dotenv dependency required by examples
- Update poetry.lock file with the new dependency

## Why
- Many example files use dotenv for loading environment variables
- This fixes import errors when running examples

## Test plan
1. \Installing dependencies from lock file

Package operations: 1 install, 0 updates, 0 removals

  - Installing python-dotenv (1.0.1)

Installing the current project: plangen (0.1.0)
2. Run examples that use dotenv