### PR TITLE
Fix docs validation workflow

### DIFF
--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -27,7 +27,16 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install markdown-link-check requests
+        pip install requests
+    
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+    
+    - name: Install markdown-link-check
+      run: |
+        npm install -g markdown-link-check
     
     - name: Check for broken links in Markdown files
       run: |


### PR DESCRIPTION
This PR fixes the documentation validation workflow by correctly using Node.js to install the markdown-link-check package, which is a npm package, not a Python package.