### PR TITLE
Fix GitHub Packages publishing workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -34,9 +34,9 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
     
-    - name: Configure Poetry
+    - name: Configure Poetry for GitHub Packages
       run: |
-        poetry config repositories.github https://github.com/cajias/plangen
+        poetry config repositories.github https://maven.pkg.github.com/cajias/plangen
         poetry config http-basic.github ${{ github.actor }} ${{ secrets.GITHUB_TOKEN }}
     
     - name: Update version if workflow dispatch

--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@ For comprehensive documentation, please see the [docs](docs/index.md) directory:
 PlanGEN is available as a package from GitHub Packages. You can install it directly using pip:
 
 ```bash
-# Authenticate with GitHub Packages
-pip install --upgrade pip
-pip install keyring
-pip install keyrings.alt
+# Create or edit ~/.pip/pip.conf (or %APPDATA%\pip\pip.ini on Windows)
+# Add the following:
+[global]
+index-url = https://pypi.org/simple
+extra-index-url = https://USERNAME:TOKEN@maven.pkg.github.com/cajias/plangen/
 
-# Set up your credentials (run once)
-# Replace USERNAME with your GitHub username and TOKEN with a GitHub personal access token
-keyring set https://github.com/cajias/plangen USERNAME TOKEN
+# Replace USERNAME with your GitHub username
+# Replace TOKEN with a GitHub personal access token with the 'read:packages' scope
 
 # Install the package
-pip install plangen --index-url https://github.com/cajias/plangen
+pip install plangen
 ```
 
 ### Installing with Poetry
@@ -55,7 +55,11 @@ Alternatively, you can add PlanGEN to your Poetry project:
 
 ```bash
 # Configure Poetry to use GitHub Packages
-poetry config repositories.plangen https://github.com/cajias/plangen
+poetry config repositories.plangen https://maven.pkg.github.com/cajias/plangen
+poetry config http-basic.plangen USERNAME TOKEN
+
+# Replace USERNAME with your GitHub username
+# Replace TOKEN with a GitHub personal access token with the 'read:packages' scope
 
 # Add the package to your project
 poetry add plangen --source plangen


### PR DESCRIPTION
This PR fixes the GitHub Packages publishing workflow by using the correct GitHub Packages URL format (maven.pkg.github.com). It also updates the installation instructions in the README with the correct approach for installing packages from GitHub Packages.