### PR TITLE
Add webhook dispatcher for centralized automations

### DIFF
--- a/.github/workflows/dispatch-automations.yml
+++ b/.github/workflows/dispatch-automations.yml
@@ -1,0 +1,45 @@
+# Minimal webhook dispatcher
+# Sends events to centralized workflow-automations repo
+
+name: Dispatch to Automations
+
+on:
+  issues:
+    types: [opened, edited, assigned]
+  pull_request:
+    types: [closed]
+
+jobs:
+  dispatch-issues:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch issue event
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.AUTOMATION_DISPATCH_TOKEN }}
+          repository: cajias/workflow-automations
+          event-type: issue-${{ github.event.action }}
+          client-payload: |
+            {
+              "repository": "${{ github.repository }}",
+              "issue_number": ${{ github.event.issue.number }},
+              "action": "${{ github.event.action }}"
+            }
+
+  dispatch-pulls:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch PR event
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.AUTOMATION_DISPATCH_TOKEN }}
+          repository: cajias/workflow-automations
+          event-type: pull_request-${{ github.event.action }}
+          client-payload: |
+            {
+              "repository": "${{ github.repository }}",
+              "pull_number": ${{ github.event.pull_request.number }},
+              "action": "${{ github.event.action }}"
+            }


### PR DESCRIPTION
This PR adds a minimal webhook dispatcher that sends events to the centralized `workflow-automations` repository.

## What this does

Instead of running automations directly in this repo, this workflow:
1. Listens for issue events (opened, edited, assigned) and PR events (closed)
2. Sends webhooks to `cajias/workflow-automations`
3. Centralized automations run and post results back here

## Automations Triggered

- **AI Triage** - Automatically analyzes and labels new issues
- **Copilot Subtask Manager** - Manages Copilot assignments for parallel subtask work

## Benefits

- ✅ All automation logic in one place
- ✅ Updates apply instantly to all repos
- ✅ No per-repo maintenance
- ✅ Real-time event response (not polling)
- ✅ Centralized configuration and monitoring

## Required Secret

This workflow requires a secret named `AUTOMATION_DISPATCH_TOKEN` to be set.

**To add the secret:**

1. Create a PAT with `repo` scope (or use existing one)
2. Go to Settings → Secrets → Actions
3. Add secret: `AUTOMATION_DISPATCH_TOKEN` = [your PAT]

**Or use GitHub CLI:**

```bash
gh secret set AUTOMATION_DISPATCH_TOKEN --repo cajias/plangen
```

Once the secret is added, the workflows will start triggering automatically.